### PR TITLE
Implement #2

### DIFF
--- a/timer.js
+++ b/timer.js
@@ -1,5 +1,11 @@
 #!/usr/bin/env node
-let seconds = 0;
+let seconds = 0,
+    error = false;
+
+// Make sure a time value is between 0 and 59
+function validateTimeRange(time) {
+  return (time >= 0 && time <= 59);
+}
 
 // Add up seconds from arguments
 process.argv.forEach((arg, index) => {
@@ -23,6 +29,10 @@ process.argv.forEach((arg, index) => {
     case 'mins':
     case 'minute':
     case 'minutes':
+      if (!validateTimeRange(number)) {
+        console.log(`Invalid argument "${number}${unit}": Minutes have to be between 0 and 59`);
+        error = true;
+      }
       seconds += number * 60;
       break;
 
@@ -31,6 +41,10 @@ process.argv.forEach((arg, index) => {
     case 'secs':
     case 'second':
     case 'seconds':
+      if (!validateTimeRange(number)) {
+        console.log(`Invalid argument "${number}${unit}": Seconds have to be between 0 and 59`);
+        error = true;
+      }
       seconds += number;
       break;
 
@@ -40,6 +54,11 @@ process.argv.forEach((arg, index) => {
       break;
   }
 })
+
+if (error) {
+  // Stop script if there is an error with the arguments
+  return;
+}
 
 let currentHour = 0,
     currentMinute = 0,

--- a/timer.js
+++ b/timer.js
@@ -1,8 +1,49 @@
 #!/usr/bin/env node
+let seconds = 0;
 
-let minutes = Number(process.argv[2]),
+// Add up seconds from arguments
+process.argv.forEach((arg, index) => {
+  if (index < 2 || !arg) return;
+  const number = Number(/\d+/.exec(arg)[0]);
+  
+  const unitStr = /[a-zA-Z]+/.exec(arg);
+  const unit = unitStr && unitStr.length >= 1 ? unitStr[0].toLowerCase() : false;
+
+  switch(unit) {
+    case 'h':
+    case 'hr':
+    case 'hrs':
+    case 'hour':
+    case 'hours':
+      seconds += number * 3600;
+      break;
+
+    case 'm':
+    case 'min':
+    case 'mins':
+    case 'minute':
+    case 'minutes':
+      seconds += number * 60;
+      break;
+
+    case 's':
+    case 'sec':
+    case 'secs':
+    case 'second':
+    case 'seconds':
+      seconds += number;
+      break;
+
+    // Default to minutes to stay compatible with previous versions
+    default:
+      seconds += number * 60;
+      break;
+  }
+})
+
+let currentHour = 0,
     currentMinute = 0,
-    currentSecond = 0;
+    currentSecond = 1; // We need to start at 1, otherwise the timer won't match up with the timeout
 
 function main () {
   let timer = setTimer();
@@ -11,12 +52,16 @@ function main () {
     clearInterval(timer);
 
     printEndMessage();
-  }, minutes * 60 * 1000);
+  }, seconds * 1000);
+}
+
+function toTwoDigit(num){
+  return num > 9 ? num: "0" + num;
 }
 
 function printTime () {
   console.clear();
-  console.log('Time (m:ss): ' + currentMinute + ':' + currentSecond % 60);
+  console.log('Time (hh:mm:ss): ' + toTwoDigit(currentHour) + ':' + toTwoDigit(currentMinute % 60) + ':' + toTwoDigit(currentSecond % 60));
 }
 
 function printEndMessage () {
@@ -27,6 +72,7 @@ function printEndMessage () {
 function setTimer () {
   return setInterval(function () {
     currentMinute = Math.floor(currentSecond / 60);
+    currentHour = Math.floor(currentMinute / 60);
     
     printTime();
 


### PR DESCRIPTION
Implementing a way to easily start timers that take seconds, minutes or hours to complete.

The script will sum up all arguments and run a timer for that many seconds.

Examples:
```sh
bash timer 5min
bash timer 5hours
bash timer 5hours 6minutes
bash timer 1second
bash timer 2seconds
bash timer 5minutes 6hours # Units don't have to be in order
bash timer 5minutes 7minutes 8minutes # A unit can be used more than once => 20 minute timer
bash timer 5 # Script stays compatible with current syntax: If no unit is provided, it will fall back to minutes
bash timer 1hour 5 # This can be used to remove the unit whenever you want to add minutes
```